### PR TITLE
Added bower manifest to enable an official kube package to added to the bower repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ less/master.less
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Bower Files
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "kube",
+  "version": "4.0.2",
+  "homepage": "http://imperavi.com/kube/",
+  "authors": [
+    "imperavi <ab@imperavi.com>"
+  ],
+  "description": "Kube is a minimalistic Web framework for professional developers and designers.",
+  "main": "js/kube.js",
+  "keywords": [
+    "HTML5",
+    "Framework",
+    "CSS",
+    "LESS",
+    "Web",
+    "Controls"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.1"
+  }
+}


### PR DESCRIPTION
Adding the Bower manifest to the official repository would mean that when you push an update, everybody who has Kube specified as a dependency in their project using Bower would get the update. At the moment there are a few bower packages of Kube which just point to outdated forks of Kube. 

The only maintenance would be bumping the version number in the bower.json file when a new version is released. 
