### PR TITLE
Obsolete as of IE9 (-ms-interpolation-mode)

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -250,5 +250,4 @@ object {
 }
 img {
 	vertical-align: middle;
-	-ms-interpolation-mode: bicubic;
 }


### PR DESCRIPTION
In your Readme.md:

````
Works in every modern browser
...
IE9+
...
````

The property `-ms-interpolation-mode`:

 * default value IE7: nearest-neighbor (low quality)
 * default value IE8: bicubic (high quality)
 * **obsolete as of IE9**

Proof link:

 * [MDN](https://developer.mozilla.org/ru/docs/Web/CSS/image-rendering)
 * [MSDN](http://msdn.microsoft.com/en-us/library/ie/ms530822(v=vs.85).aspx)





