### PR TITLE
use prefixed flex-basis in grid-column mixin

### DIFF
--- a/src/_scss/mixins/_grid.scss
+++ b/src/_scss/mixins/_grid.scss
@@ -12,9 +12,9 @@
 
 	$width: (100% / $grid-columns) * $num;
 
-    flex-basis: $width;
-    max-width: $width;
-    width: $width;
+	@include flex-basis($width);
+    	max-width: $width;
+    	width: $width;
 }
 
 // column offset


### PR DESCRIPTION
flex-basis is not recognized on Safari 8, needs to be prefixed.