### PR TITLE
Fix sm breakpoint

### DIFF
--- a/src/_scss/_variables.scss
+++ b/src/_scss/_variables.scss
@@ -1,6 +1,6 @@
 // BREAKPOINTS
 // ---------------------------------------------------------------------------
-$sm: 768px !default;
+$sm: 769px !default;
 $md: 1024px !default;
 $lg: 1200px !default;
 


### PR DESCRIPTION
768px breakpoint results in elements disappearing if they have a class of `.show-sm`, show below using Kube's Hugo theme:
![issue](https://cloud.githubusercontent.com/assets/23447618/25735832/abb7604a-31a0-11e7-989e-a424ca3ece7c.PNG)

The fix would be to set the breakpoint at 769px, like so:
![fix](https://cloud.githubusercontent.com/assets/23447618/25735844/c515e32c-31a0-11e7-8752-f1fd66802096.PNG)

Further testing proves that changing the breakpoint value to 769px does not cause further issues with disappearing elements.

However, this only proves that the .show-sm class has issues, and no testing was done to ensure that this will not cause issues to other classes/mixins 





