### PR TITLE
 #132 Form's legend overlay fieldset border in Firefox issue fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+\.idea/

--- a/src/_scss/components/_forms.scss
+++ b/src/_scss/components/_forms.scss
@@ -14,7 +14,7 @@ legend {
 	margin-left: -1rem;
 	top: 2px;
 	position: relative;
-	line-height: 0;
+	line-height: 0.01;
 }
 input,
 textarea,


### PR DESCRIPTION
Firefox displays elements with `line-height: 0` with empty sizing. Changed value to `0.01`.